### PR TITLE
Added ability to send custom headers.

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -7,6 +7,7 @@ import { Dispatch, useCallback, useRef } from 'react';
 export type CreateOptions<Schema> = {
   endpoint: string;
   schema: Schema;
+  headers?: Record<string, string>;
 };
 
 interface CommonHookOptions<TData> {
@@ -86,6 +87,7 @@ export const useFetchCallback = (
   dispatch: Dispatch<IDispatch>,
   endpoint: string,
   fetchPolicy: FetchPolicy | undefined,
+  headers?: Record<string, string>,
   effects?: {
     onPreEffect?: () => void;
     onSuccessEffect?: () => void;
@@ -114,6 +116,7 @@ export const useFetchCallback = (
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...headers,
         },
         body: JSON.stringify({
           query: type !== 'query' ? type + query : query,
@@ -163,6 +166,6 @@ export const useFetchCallback = (
 
       return json;
     },
-    [dispatch, endpoint, fetchPolicy, type]
+    [dispatch, endpoint, fetchPolicy, headers, type]
   );
 };

--- a/src/useMutation.ts
+++ b/src/useMutation.ts
@@ -35,6 +35,7 @@ export const createUseMutation = <
 >({
   endpoint,
   schema,
+  headers,
 }: CreateOptions<Schema>) => <TData = unknown>(
   mutationFn: MutationFn<TData, Mutation>,
   options: MutationOptions<TData> = {}
@@ -55,6 +56,7 @@ export const createUseMutation = <
     dispatch,
     endpoint,
     fetchPolicy,
+    headers,
     {
       onPreEffect: () => {
         switch (fetchPolicy) {

--- a/src/useQuery.ts
+++ b/src/useQuery.ts
@@ -46,6 +46,7 @@ export const createUseQuery = <
 >({
   endpoint,
   schema,
+  headers,
 }: CreateOptions<Schema>) => <TData = unknown>(
   queryFn: QueryFn<TData, Query>,
   options: QueryOptions<TData> = {}
@@ -69,7 +70,12 @@ export const createUseQuery = <
     lazy ? LazyInitialState : EarlyInitialState
   );
 
-  const fetchQuery = useFetchCallback(dispatch, endpoint, fetchPolicy);
+  const fetchQuery = useFetchCallback(
+    dispatch,
+    endpoint,
+    fetchPolicy,
+    headers
+  );
 
   const initialQueryClient = useMemo(() => {
     return new Client<Query>(schema.Query, fetchQuery);


### PR DESCRIPTION
As mentioned in #1 I need to send additional authorization headers to reach my GraphQL endpoint. I think this is a good feature anyways, so I provided a implementation to support this feature.